### PR TITLE
Support deploying subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ name: Deploy Platformatic DB application to the cloud
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - "docs/**"
+      - "**.md"
 
 jobs:
   build_and_deploy:
@@ -36,4 +36,16 @@ jobs:
           custom_variable1: test2
           custom_variable2: test3
           custom_secret1: test5
+```
+
+## Monorepo/Subdirectory support
+
+Use the [`jobs.<job_id>.defaults.run.working-directory`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun) to specify the subdirectory of the project to deploy, this will ensure that all commands are run from the correct directory.
+
+```yml
+jobs:
+  build_and_deploy:
+    defaults:
+      run:
+        working-directory: <subdirectory>
 ```

--- a/action.js
+++ b/action.js
@@ -193,7 +193,7 @@ async function run () {
     const pathToConfig = core.getInput('platformatic_config_path')
     const pathToEnvFile = core.getInput('platformatic_env_path')
 
-    const pathToProject = process.env.GITHUB_WORKSPACE
+    const pathToProject = core.getInput('platformatic_project_path') || '.'
     const deployServiceHost = process.env.DEPLOY_SERVICE_HOST
 
     const githubToken = core.getInput('github_token')

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   platformatic_workspace_key:
     description: 'Platformatic workspace key'
     required: true
+  platformatic_project_path:
+    description: 'Path to the Platformatic application project'
+    required: false
   platformatic_config_path:
     description: 'Path to the Platformatic config file'
     required: false

--- a/test/execute.js
+++ b/test/execute.js
@@ -24,7 +24,7 @@ async function run () {
   }
 
   process.env = Object.assign({}, defaultEnvVars, process.env)
-  process.env.GITHUB_WORKSPACE = repositoryPath
+  process.env[`INPUT_${'platformatic_project_path'.replace(/ /g, '_').toUpperCase()}`] = repositoryPath
 
   try {
     const executeAction = require('../action.js')


### PR DESCRIPTION
suuport deploying a subdirectory by setting pathToProject to the platformatic_project_path input or to the current working directory
this way if we have monorepo we can use  `working-directory`  to set the directory were to run all our steps https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iddefaults 