### PR TITLE
Add action input: post_pr_comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Github action to deploy Platformatic DB application to the cloud
+# GitHub Action to deploy a Platformatic app to Platformatic Cloud
 
-Example of usage:
+Example usage:
 
 ```yml
-name: Deploy Platformatic DB application to the cloud
+name: Deploy Platformatic app to Platformatic cloud
 
 on:
   pull_request:
@@ -20,14 +20,17 @@ jobs:
     steps:
       - name: Checkout application project repository
         uses: actions/checkout@v3
-      - name: npm install --omit=dev
+
+      - name: Install app dependencies
         run: npm install --omit=dev
-      - name: Deploy project
-        uses: platformatic/onestep@v1
+
+      - name: Deploy app
+        id: deploy-app
+        uses: platformatic/onestep@v1.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          platformatic_workspace_id: df8d6d16-7cf3-448f-a192-c14daaaf98da
-          platformatic_workspace_key: ${{ secrets.PLATFORMATIC_WORKSPACE_KEY }}
+          platformatic_workspace_id: ${{ vars.PLATFORMATIC_WORKSPACE_ID }}
+          platformatic_workspace_key: ${{ secrets.PLATFORMATIC_WORKSPACE_API_KEY }}
           platformatic_config_path: ./platformatic.db.json
           post_pr_comment: false
           variables: custom_variable1, custom_variable2
@@ -37,4 +40,7 @@ jobs:
           custom_variable1: test2
           custom_variable2: test3
           custom_secret1: test5
+
+      - name: Output deployed app URL
+        run: echo '${{ steps.deploy-app.outputs.platformatic_app_url }}'
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ jobs:
           platformatic_workspace_id: df8d6d16-7cf3-448f-a192-c14daaaf98da
           platformatic_workspace_key: ${{ secrets.PLATFORMATIC_WORKSPACE_KEY }}
           platformatic_config_path: ./platformatic.db.json
+          post_pr_comment: false
           variables: custom_variable1, custom_variable2
           secrets: custom_secret1
         env:

--- a/action.js
+++ b/action.js
@@ -235,7 +235,9 @@ async function run () {
       logger
     })
 
-    if (isPullRequest) {
+    const postPrComment = core.getInput('post_pr_comment') === 'true'
+
+    if (isPullRequest && postPrComment) {
       const commitHash = githubMetadata.commit.sha
       const commitUrl = githubMetadata.repository.url + '/commit/' + commitHash
       const platformaticComment = createPlatformaticComment(entryPointUrl, commitHash, commitUrl)

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
   secrets:
     description: 'Comma separated list of environment secrets to be passed to the Platformatic application'
     required: false
+  post_pr_comment:
+    description: 'Configure whether comments with preview app URLs are posted on pull requests'
+    required: false
+    default: true
 outputs:
   platformatic_app_url:
     description: 'URL of the deployed Platformatic DB application'


### PR DESCRIPTION
This option is `true` by default, but if it's set to `false` it will disable comments being posted on pull requests after a successful deploy.

This gives users more control, for example if they wish to implement a step in their GitHub Actions workflow which posts a pull request comment.

Tested on this pull request: https://github.com/simonplend/blog/pull/6

### Tasks

- [x] Update `latest` tag after this PR is merged